### PR TITLE
Converte ALLOWED_UNIDADES para string #7

### DIFF
--- a/django_oauth_usp/accounts/models.py
+++ b/django_oauth_usp/accounts/models.py
@@ -26,7 +26,7 @@ class UserModel(AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = 'login'
     REQUIRED_FIELDS = ['name', 'user_type', 'main_email']
     EMAIL_FIELD = 'main_email'
-    ALLOWED_UNIDADES = settings.ALLOWED_UNIDADES
+    ALLOWED_UNIDADES = str(settings.ALLOWED_UNIDADES)
 
     class Meta:
         verbose_name = _('user')


### PR DESCRIPTION
Converte a variável ALLOWED_UNIDADES para string
para que possa ser utilizada na comparação com a unidade
do usuário dentro da função unidade_is_allowed, localizada
em django_oauth_usp.accounts.models.UserModel